### PR TITLE
chore(CI): add action to auto add new issues to PF project board

### DIFF
--- a/.github/workflows/add-new-issues-to-project.yml
+++ b/.github/workflows/add-new-issues-to-project.yml
@@ -1,0 +1,16 @@
+name: Add new issues to PatternFly Issues project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/patternfly/projects/7
+          github-token: ${{ secrets.GH_PROJECTS }}


### PR DESCRIPTION
There was an interested expressed in tracking these issues on the PF project board, this GH action will automatically add issues created in this repo to the board for that purpose.